### PR TITLE
Switched to a byte-by-byte parser with less state.

### DIFF
--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -5,7 +5,7 @@ include(FetchContent)
 FetchContent_Declare(
   byteme
   GIT_REPOSITORY https://github.com/LTLA/byteme
-  GIT_TAG 8a13a7ea0ea0712c2efb31c05f96d10f9efbfd41
+  GIT_TAG e95bc33c1a6677110582d6ac1c369de1fb286e8d
 )
 
 FetchContent_MakeAvailable(byteme)

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -5,7 +5,7 @@ include(FetchContent)
 FetchContent_Declare(
   byteme
   GIT_REPOSITORY https://github.com/LTLA/byteme
-  GIT_TAG e95bc33c1a6677110582d6ac1c369de1fb286e8d
+  GIT_TAG 9ae37144bb943c5d66e3c9b15d71257e6281adce
 )
 
 FetchContent_MakeAvailable(byteme)

--- a/include/comservatory/Parser.hpp
+++ b/include/comservatory/Parser.hpp
@@ -13,6 +13,8 @@
 #include "Field.hpp"
 #include "Creator.hpp"
 
+#include "byteme/PerByte.hpp"
+
 /**
  * @file Parser.hpp
  *
@@ -99,156 +101,296 @@ public:
     }
 
 private:
-    void check_new_line(Contents& info) {
-        if (on_header) {
-            auto copy = info.names;
-            std::sort(copy.begin(), copy.end());
-            for (size_t s = 1; s < copy.size(); ++s) {
-                if (copy[s] == copy[s-1]) {
-                    throw std::runtime_error("detected duplicated header names");
-                }
-            }
+    static Field* fetch_column(Contents& info, size_t column, size_t line) {
+        auto& everything = info.fields;
+        if (column >= everything.size()) {
+            throw std::runtime_error("more fields on line " + std::to_string(line + 1) + " than expected from the header");
+        }
+        return everything[column].get();
+    }
 
-            info.fields.resize(info.names.size());
-            for (auto& o : info.fields) {
-                o.reset(new UnknownField);
-            }
+    Field* check_column_type(Contents& info, Type observed, size_t column, size_t line) const {
+        Field* current = fetch_column(info, column, line);
+        auto expected = current->type();
 
-            on_header = false;
-        } else if (field_counter + 1 != info.fields.size()) {
-            throw std::runtime_error("fewer fields than expected from the header");
+        if (expected == UNKNOWN) {
+            bool use_dummy = check_store && 
+                to_store_by_name.find(info.names[column]) == to_store_by_name.end() &&
+                to_store_by_index.find(column) == to_store_by_index.end();
+
+            auto ptr = creator->create(observed, current->size(), use_dummy);
+            info.fields[column].reset(ptr);
+            current = info.fields[column].get();
+        } else if (expected != observed) {
+            throw std::runtime_error("previous and current types do not match up");
+        }
+
+        return current;
+    }
+
+    template<class Input>
+    void store_nan(Input& input, Contents& info, size_t column, size_t line) const {
+        input.advance();
+        expect_fixed(input, "an", "AN", column, line); // i.e., NaN or any of its capitalizations.
+        auto* current = check_column_type(info, NUMBER, column, line);
+        static_cast<NumberField*>(current)->push_back(std::numeric_limits<double>::quiet_NaN());
+    }
+
+    template<class Input>
+    void store_inf(Input& input, Contents& info, size_t column, size_t line, bool negative) const {
+        input.advance();
+        expect_fixed(input, "nf", "NF", column, line); // i.e., Inf or any of its capitalizations.
+        auto* current = check_column_type(info, NUMBER, column, line);
+
+        double val = std::numeric_limits<double>::infinity();
+        if (negative) {
+            val *= -1;
+        }
+        static_cast<NumberField*>(current)->push_back(val);
+    }
+
+    template<class Input>
+    void store_na_or_nan(Input& input, Contents& info, size_t column, size_t line) const {
+        // Some shenanigans required here to distinguish between
+        // NAN/NaN/etc. and NA, given that both are allowed.
+        if (!input.valid()) {
+            throw std::runtime_error("truncated field in " + get_location(column, line));
+        }
+        input.advance();
+
+        char second = input.get();
+        bool is_missing = true;
+        if (second == 'a') {
+            is_missing = false;
+        } else if (second != 'A') {
+            throw std::runtime_error("unknown value in " + get_location(column, line));
+        }
+
+        if (!input.valid()) {
+            throw std::runtime_error("truncated field in " + get_location(column, line));
+        }
+        input.advance();
+
+        char next = input.get();
+        if (next == 'n' || next == 'N') {
+            auto* current = check_column_type(info, NUMBER, column, line);
+            static_cast<NumberField*>(current)->push_back(std::numeric_limits<double>::quiet_NaN());
+            input.advance(); // for consistency with the NA case, in the sense that we are always past the keyword regardless of whether the keyword is NaN or NA.
+        } else {
+            auto raw = fetch_column(info, column, line);
+            raw->add_missing();
         }
     }
 
-    void add_entry(Contents& info, const char* x, size_t n) {
-        if (buffer.size()) {
-            buffer.insert(buffer.end(), x, x + n);
-            add_entry_raw(info, buffer.data(), buffer.size());
-            buffer.clear();
-        } else {
-            add_entry_raw(info, x, n);
+    template<class Input>
+    void store_number_or_complex(Input& input, Contents& info, size_t column, size_t line, bool negative) {
+        auto first = to_number(input, column, line);
+        if (negative) {
+            first *= -1;
         }
-    }
 
-    template<typename Char>
-    void add_entry_raw(Contents& info, const Char* x, size_t n) {
-        if (on_header) {
-            info.names.push_back(to_string(x, n));
-        } else {
-            auto& everything = info.fields;
-            if (field_counter >= everything.size()) {
-                throw std::runtime_error("more fields than expected from the header");
-            }
-
-            auto* current = everything[field_counter].get();
-            auto observed = decide_type(x, n);
-            if (observed == UNKNOWN) {
-                current->add_missing();
-            } else {
-                auto expected = current->type();
-                if (expected == UNKNOWN) {
-                    expected = observed;
-
-                    bool use_dummy = check_store && 
-                        to_store_by_name.find(info.names[field_counter]) == to_store_by_name.end() &&
-                        to_store_by_index.find(field_counter) == to_store_by_index.end();
-
-                    auto ptr = creator->create(observed, current->size(), use_dummy);
-                    everything[field_counter].reset(ptr);
-
-                    current = everything[field_counter].get();
-
-                } else if (expected != observed) {
-                    throw std::runtime_error("previous and current types do not match up");
-                }
-
-                switch (expected) {
-                    case STRING:
-                        static_cast<StringField*>(current)->push_back(to_string(x, n));
-                        break;
-                    case NUMBER:
-                        static_cast<NumberField*>(current)->push_back(to_number(x, n));
-                        break;
-                    case COMPLEX:
-                        static_cast<ComplexField*>(current)->push_back(to_complex(x, n));
-                        break; 
-                    case BOOLEAN:
-                        static_cast<BooleanField*>(current)->push_back(to_boolean(x, n));
-                        break; 
-                    case UNKNOWN:
-                        throw std::runtime_error("cannot add UNKNOWN type");
-                }
-            }
+        char next = input.get(); // to need to check validity, as to_number always leaves us in a valid state (or throws itself).
+        if (next == ',' || next == '\n') {
+            auto* current = check_column_type(info, NUMBER, column, line);
+            static_cast<NumberField*>(current)->push_back(first);
+            return;
         }
-        return;
+
+        char second_neg = false;
+        if (next == '-') {
+            second_neg = true;
+        } else if (next != '+') {
+            throw std::runtime_error("incorrectly formatted number in " + get_location(column, line));
+        }
+
+        input.advance();
+        if (!input.valid()) {
+            throw std::runtime_error("truncated complex number in " + get_location(column, line));
+        } else if (!std::isdigit(input.get())) {
+            throw std::runtime_error("incorrectly formatted complex number in " + get_location(column, line));
+        }
+
+        auto second = to_number(input, column, line);
+        if (second_neg) {
+            second *= -1;
+        }
+        if (input.get() != 'i') { // again, no need to check validity.
+            throw std::runtime_error("incorrectly formatted complex number in " + get_location(column, line));
+        }
+        input.advance(); // for consistency with the numbers, in the sense that we are always past the keyword regardless of whether we're a NUMBER or COMPLEX.
+
+        auto* current = check_column_type(info, COMPLEX, column, line);
+        static_cast<ComplexField*>(current)->push_back(std::complex<double>(first, second));
     }
 
 private:
-    void parse_loop(const char* ptr, size_t length, Contents& info) {
-        size_t previous = 0;
-        for (size_t i = 0; i < length; ++i) {
-            char c = ptr[i];
+    template<class Input>
+    void parse_loop(Input& input, Contents& info) {
+        if (!input.valid()) {
+            throw std::runtime_error("CSV file is empty");
+        }
 
-            if (on_string) {
-                if (c == '"') {
-                    on_quote = !on_quote;
-
-                } else if (c == ',') {
-                    if (on_quote) {
-                        add_entry(info, ptr + previous, i - previous);
-                        previous = i + 1; // skip past the comma.
-                        ++field_counter;
-                        on_string = false;
-                        on_quote = false;
-                    }
-
-                } else if (c == '\n') {
-                    if (on_quote) {
-                        add_entry(info, ptr + previous, i - previous); 
-                        check_new_line(info);
-                        previous = i + 1; // skip past the newline.
-                        field_counter = 0;
-                        on_string = false;
-                        on_quote = false;
-                    }
+        // Special case for a new-line only file.
+        if (input.get() == '\n') {
+            auto& line = info.fallback;
+            while (1) {
+                input.advance();
+                if (!input.valid()) {
+                    break;
                 }
-            } else {
-                if (c == ',') {
-                    add_entry(info, ptr + previous, i - previous);
-                    previous = i + 1; // skip past the comma.
-                    ++field_counter;
-
-                } else if (c == '"') {
-                    if (previous != i) {
-                        throw std::runtime_error("encountered quote in the middle of a non-string entry");
-                    }
-                    on_string = true;
-
-                } else if (c == '\n') {
-                    if (field_counter == 0 && i == previous) {
-                        // It's a zero-column file. If on_header is true, then
-                        // this declares that there are no columns; if false but info.names 
-                        // is empty, we're simply proceeding by not adding any values. 
-                        if (on_header) {
-                            on_header = false; 
-                        } else if (info.names.empty()) {
-                            ++info.fallback;
-                        } else {
-                            throw std::runtime_error("encountered empty line in a file with non-zero columns"); 
-                        }
-                    } else {
-                        add_entry(info, ptr + previous, i - previous);
-                        check_new_line(info);
-                    }
-                    previous = i + 1; // skip past the newline.
-                    field_counter = 0;
+                ++line;
+                if (input.get() != '\n') {
+                    throw std::runtime_error("more fields on line " + std::to_string(line + 1) + " than expected from the header");
                 }
+            }
+            return;
+        }
+
+        // Processing the header.
+        while (1) {
+            char c = input.get();
+            if (c != '"') {
+                throw std::runtime_error("all headers should be quoted strings");
+            }
+
+            info.names.push_back(to_string(input, info.names.size(), 0));
+            if (!input.valid()) {
+                throw std::runtime_error("truncated headers without a trailing newline");
+            }
+
+            char next = input.get();
+            input.advance();
+            if (next == '\n') {
+                break;
+            } else if (next != ',') {
+                throw std::runtime_error("header " + std::to_string(info.names.size()) + " contains trailing character '" + std::string(1, next) + "'"); 
+            }
+        } 
+
+        auto copy = info.names;
+        std::sort(copy.begin(), copy.end());
+        for (size_t s = 1; s < copy.size(); ++s) {
+            if (copy[s] == copy[s-1]) {
+                throw std::runtime_error("detected duplicated header names");
             }
         }
 
-        // Storing content in the buffer.
-        if (previous < length) {
-            buffer.insert(buffer.end(), ptr + previous, ptr + length);
+        info.fields.resize(info.names.size());
+        for (auto& o : info.fields) {
+            o.reset(new UnknownField);
+        }
+
+        // Special case if there are no records, i.e., it's header-only.
+        if (!input.valid()) {
+            return;
+        }
+
+        // Processing the records in a CSV.
+        size_t column = 0;
+        size_t line = 1;
+        while (1) {
+            switch (input.get()) {
+                case '"':
+                    {
+                        auto* current = check_column_type(info, STRING, column, line);
+                        static_cast<StringField*>(current)->push_back(to_string(input, column, line));
+                    }
+                    break;
+
+                case 't': case 'T':
+                    {
+                        input.advance();
+                        expect_fixed(input, "rue", "RUE", column, line);
+                        auto* current = check_column_type(info, BOOLEAN, column, line);
+                        static_cast<BooleanField*>(current)->push_back(true);
+                    }
+                    break;
+
+                case 'f': case 'F':
+                    {
+                        input.advance();
+                        expect_fixed(input, "alse", "ALSE", column, line);
+                        auto* current = check_column_type(info, BOOLEAN, column, line);
+                        static_cast<BooleanField*>(current)->push_back(false);
+                    }
+                    break;
+
+                case 'N':
+                    store_na_or_nan(input, info, column, line);
+                    break;
+
+                case 'n': 
+                    store_nan(input, info, column, line);
+                    break;
+                
+                case 'i': case 'I':
+                    store_inf(input, info, column, line, false);
+                    break;
+
+                case '0': case '1': case '2': case '3': case '4': case '5': case '6': case '7': case '8': case '9':
+                    store_number_or_complex(input, info, column, line, false);
+                    break;
+
+                case '+':
+                    input.advance();
+                    if (!input.valid()) {
+                        throw std::runtime_error("truncated field in " + get_location(column, line)); 
+                    } else if (!std::isdigit(input.get())) {
+                        throw std::runtime_error("invalid number in " + get_location(column, line)); 
+                    }
+                    store_number_or_complex(input, info, column, line, false);
+                    break;
+
+                case '-':
+                    {
+                        input.advance();
+                        if (!input.valid()) {
+                            throw std::runtime_error("truncated field in " + get_location(column, line));
+                        }
+
+                        char next = input.get();
+                        if (next == 'i' || next == 'I') {
+                            store_inf(input, info, column, line, true);
+                        } else if (next == 'n' || next == 'N') {
+                            store_nan(input, info, column, line);
+                        } else if (std::isdigit(next)) {
+                            store_number_or_complex(input, info, column, line, true);
+                        } else {
+                            throw std::runtime_error("incorrectly formatted number in " + get_location(column, line));
+                        }
+                    }
+                    break;
+
+                case '\n':
+                    throw std::runtime_error(get_location(column, line) + " is empty");
+
+                default:
+                    throw std::runtime_error("unknown type starting with '" + std::string(1, input.get()) + "' in " + get_location(column, line));
+            }
+
+            if (!input.valid()) {
+                throw std::runtime_error("last line must be terminated by a single newline");
+            }
+
+            char next = input.get();
+            input.advance();
+            if (next == ',') {
+                ++column;
+                if (!input.valid()) {
+                    throw std::runtime_error("line " + std::to_string(line + 1) + " is truncated at column " + std::to_string(column + 1));
+                }
+            } else if (next == '\n') {
+                if (column + 1 != info.names.size()) {
+                    throw std::runtime_error("line " + std::to_string(line + 1) + " has fewer fields than expected from the header");
+                }
+                if (!input.valid()) {
+                    break;
+                }
+                column = 0;
+                ++line;
+            } else {
+                throw std::runtime_error(get_location(column, line) + " contains trailing character '" + std::string(1, next) + "'"); 
+            }
         }
     }
 
@@ -256,61 +398,14 @@ public:
     template<class Reader>
     void parse(Reader& reader, Contents& info, bool parallel) {
         if (parallel) {
-            std::vector<unsigned char> holding;
-            bool ok = reader();
-            std::thread runner;
-
-            while (1) {
-                // Need to reinterpret_cast to interpret bytes as text.
-                auto ptr = reinterpret_cast<const char*>(reader.buffer());
-                size_t n = reader.available();
-
-                if (!ok) {
-                    parse_loop(ptr, n, info);
-                    break;
-                } 
-
-                holding.resize(n);
-                std::copy(ptr, ptr + n, holding.begin());
-                runner = std::thread([&]() -> void { 
-                    ok = reader(); 
-                });
-
-                parse_loop(reinterpret_cast<const char*>(holding.data()), n, info);
-                runner.join();
-            }
-
+            byteme::PerByteParallel input(reader);
+            parse_loop(input, info);
         } else {
-            bool ok = true;
-            while (ok) {
-                ok = reader();
-                size_t n = reader.available();
-                auto ptr = reinterpret_cast<const char*>(reader.buffer());
-                parse_loop(ptr, n, info);
-            }
+            byteme::PerByte input(reader);
+            parse_loop(input, info);
         }
     }
 
-    void finish() {
-        // If we didn't end on a newline, then field_counter > 0 (if more fields
-        // were added) or the buffer is non-empty (if we're caught in the middle
-        // of adding a new first field). 
-        if (field_counter != 0 || buffer.size()) {
-            if (on_string && !on_quote) {
-                throw std::runtime_error("string not terminated by a double quote");
-            } else {
-                throw std::runtime_error("last record must be terminated by a single newline");
-            }
-        }
-    }
-
-private:
-    bool on_header = true; 
-    bool on_string = false;
-    bool on_quote = false;
-    std::vector<char> buffer;
-
-    int field_counter = 0;
     const FieldCreator* creator;
 
     bool check_store = false;

--- a/include/comservatory/Parser.hpp
+++ b/include/comservatory/Parser.hpp
@@ -195,7 +195,7 @@ private:
             first *= -1;
         }
 
-        char next = input.get(); // to need to check validity, as to_number always leaves us in a valid state (or throws itself).
+        char next = input.get(); // no need to check validity, as to_number always leaves us on a valid position (or throws itself).
         if (next == ',' || next == '\n') {
             auto* current = check_column_type(info, NUMBER, column, line);
             static_cast<NumberField*>(current)->push_back(first);
@@ -259,10 +259,7 @@ private:
                 throw std::runtime_error("all headers should be quoted strings");
             }
 
-            info.names.push_back(to_string(input, info.names.size(), 0));
-            if (!input.valid()) {
-                throw std::runtime_error("truncated headers without a trailing newline");
-            }
+            info.names.push_back(to_string(input, info.names.size(), 0)); // no need to check validity, as to_string always leaves us on a valid position (or throws itself).
 
             char next = input.get();
             input.advance();

--- a/include/comservatory/ReadCsv.hpp
+++ b/include/comservatory/ReadCsv.hpp
@@ -77,7 +77,6 @@ private:
 
         Contents output;
         parser.parse(reader, output, parallel);
-        parser.finish();
         return output;
     }
 

--- a/include/comservatory/Type.hpp
+++ b/include/comservatory/Type.hpp
@@ -21,37 +21,6 @@ enum Type {
 };
 
 /**
- * @tparam Char Type of character field, typically a `char` or `unsigned char`.
- *
- * @param[in] x Pointer to an array of characters containing a field of interest.
- * @param n Length of the array in `x`.
- */
-template<typename Char>
-Type decide_type(const Char* x, size_t n) {
-    if (!n) {
-        throw std::runtime_error("could not determine type for an empty entry");
-    }
-    
-    if (n == 2 && x[0] == 'N' && x[1] == 'A') {
-        return UNKNOWN;
-    }
-
-    if (x[0] == '"') {
-        return STRING;
-    }
-
-    if (x[0] == 'T' || x[0] == 't' || x[0] == 'F' || x[0] == 'f') {
-        return BOOLEAN;
-    }
-
-    if (x[n-1] == 'i') {
-        return COMPLEX;
-    }
-
-    return NUMBER;
-}
-
-/**
  * @param type Type of a field.
  * @return String containing the type of the field.
  */

--- a/include/comservatory/convert.hpp
+++ b/include/comservatory/convert.hpp
@@ -9,244 +9,181 @@
 
 namespace comservatory {
 
-template<bool escape_quote=true>
-std::string to_string(const char* x, size_t n) {
-    if (n < 2 || x[0] != '"' || x[n-1] != '"') {
-        throw std::runtime_error("string entry must start and end with a double quote");
-    }
-    ++x;
-    n -= 2;
-
-    if (escape_quote) {
-        std::string output;
-        output.reserve(n);
-        
-        bool last_quote = false;
-        for (size_t i = 0; i < n; ++i) {
-            if (x[i] == '"') {
-                if (last_quote) {
-                    output += '"';
-                    last_quote = false;
-                } else {
-                    last_quote = true;
-                }
-            } else {
-                if (last_quote) {
-                    throw std::runtime_error("all double quotes should be escaped by another double quote");
-                }
-                output += x[i];
-            }
-        }
-
-        if (last_quote) {
-            throw std::runtime_error("all double quotes should be escaped by another double quote");
-        }
-        return output;
-    } else {
-        return std::string(x, x + n);
-    }
+inline std::string get_location(size_t column, size_t line) {
+    return std::string("field ") + std::to_string(column + 1) + " of line " + std::to_string(line + 1);
 }
 
-template<bool integer=false>
-double to_number_simple(const char* x, size_t n) {
-    double val = 0;
-    bool is_minus = false;
-    bool past_decimal = false;
-    bool has_number_before_decimal = false;
-    bool has_number_after_decimal = false;
-    double frac = 0.1;
+// Assumes that the first character is the double quote.
+template<class Input>
+std::string to_string(Input& input, size_t column, size_t line) {
+    std::string output;
 
-    for (size_t i = 0; i < n; ++i) {
-        char c = x[i];
-        if (i == 0) {
-            if (c == '+' || c == '-') {
-                is_minus = (c == '-');
-                continue;
-            }
+    while (1) {
+        input.advance();
+        if (!input.valid()) {
+            throw std::runtime_error("truncated string in " + get_location(column, line));
         }
 
-        if (c == '.') {
-            if (integer) {
-                throw std::runtime_error("detected a decimal point when only integer values are allowed");
+        char next = input.get();
+        if (next == '"') {
+            input.advance();
+            if (!input.valid()) {
+                throw std::runtime_error("line " + std::to_string(line + 1) + " should be terminated with a newline");
             }
-            if (!past_decimal) {
-                if (!has_number_before_decimal) {
-                    throw std::runtime_error("numbers should be present before the decimal point");
-                }
-                past_decimal = true;
+
+            if (input.get() != '"') {
+                break;
             } else {
-                throw std::runtime_error("multiple decimal points detected");
-            }
-        } else if (std::isdigit(c)) {
-            double latest = c - '0'; 
-            if (past_decimal) {
-                has_number_after_decimal = true;
-                val += frac * latest;
-                frac /= 10;
-            } else {
-                has_number_before_decimal = true;
-                val *= 10;
-                val += latest;
+                output += '"';
             }
         } else {
-            throw std::runtime_error("invalid character detected (" + std::string(1, x[i]) + ")");
+            output += next;
         }
     }
 
-    if (past_decimal && !has_number_after_decimal) {
-        throw std::runtime_error("numbers should be present after the decimal point"); 
-    }
-    if (!past_decimal && !has_number_before_decimal) {
-        throw std::runtime_error("no numbers detected in the input string");
-    }
-
-    if (is_minus) {
-        val *= -1;
-    }
-    return val;
-} 
-
-inline std::pair<bool, double> to_number_special(const char* x, size_t n) {
-    bool okay = false;
-    double val = 0;
-
-    if (n && n >= 3 && n <= 4) {
-        bool negate = (x[0] == '-');
-        if (negate) {
-            ++x;
-            --n;
-        }
-
-        if (n == 3) {
-            std::array<char, 3> lowered;
-            for (size_t i = 0; i < 3; ++i) {
-                lowered[i] = std::tolower(x[i]);
-            }
-
-            constexpr std::array<char, 3> nan = { 'n', 'a', 'n' };
-            constexpr std::array<char, 3> inf = { 'i', 'n', 'f' };
-
-            if (lowered == nan) {
-                okay = true;
-                val = std::numeric_limits<double>::quiet_NaN();
-            } else if (lowered == inf) {
-                okay = true;
-                val = std::numeric_limits<double>::infinity();
-                if (negate) {
-                    val *= -1;
-                }
-            }
-        }
-    }
-
-    return std::make_pair(okay, val);
+    return output;
 }
 
-inline double to_number(const char* x, size_t n) {
-    // First pass through to identify any 'e' values.
-    int e_found = -1;
-    for (size_t i = 0; i < n; ++i) {
-        if (x[i] == 'e' || x[i] == 'E') {
-            e_found = i;
+template<class Input>
+void expect_fixed(Input& input, const std::string& lower, const std::string& upper, size_t column, size_t line) {
+    for (size_t i = 0; i < lower.size(); ++i) {
+        if (!input.valid()) {
+            throw std::runtime_error("truncated keyword in " + get_location(column, line));
+        }
+        char x = input.get();
+        if (x != lower[i] && x != upper[i]) {
+            throw std::runtime_error("unknown keyword in " + get_location(column, line));
+        }
+        input.advance();
+    }
+}
+
+template<class Input>
+double to_number(Input& input, size_t column, size_t line) {
+    double value = 0;
+    double fractional = 10;
+    double exponent = 0; 
+    bool negative_exponent = false;
+
+    auto is_terminator = [](char v) -> bool {
+        return v == ',' || v == '\n' || v == '+' || v == '-' || v == 'i'; // last three are terminators for complex numbers.
+    };
+
+    bool in_fraction = false;
+    bool in_exponent = false;
+
+    // We assume we're starting from a digit, after handling any preceding sign. 
+    char lead = input.get();
+    value += lead - '0';
+    input.advance();
+
+    while (1) {
+        if (!input.valid()) {
+            throw std::runtime_error("line " + std::to_string(line + 1) + " should be terminated with a newline");
+        }
+        char val = input.get();
+        if (val == '.') {
+            in_fraction = true;
             break;
+        } else if (val == 'e' || val == 'E') {
+            in_exponent = true;
+            break;
+        } else if (is_terminator(val)) {
+            return value;
+        } else if (!std::isdigit(val)) {
+            throw std::runtime_error("invalid number containing '" + std::string(1, val) + "' at " + get_location(column, line));
         }
+        value *= 10;
+        value += val - '0';
+        input.advance();
     }
 
-    // Figuring out what to do with it.
-    double val;
-    if (e_found < 0) {
-        auto specs = to_number_special(x, n);
-        if (specs.first) {
-            val = specs.second;
-        } else {
-            try {
-                val = to_number_simple<false>(x, n);
-            } catch (std::exception& e) {
-                throw std::runtime_error("failed to convert string to number:\n  - " + std::string(e.what()));
+    if (in_fraction) {
+        input.advance();
+        if (!input.valid()) {
+            throw std::runtime_error("line " + std::to_string(line + 1) + " should be terminated with a newline");
+        }
+
+        char val = input.get();
+        if (!std::isdigit(val)) {
+            throw std::runtime_error("'.' must be followed by at least one digit at " + get_location(column, line));
+        }
+        value += (val - '0') / fractional;
+
+        input.advance();
+        while (1) {
+            if (!input.valid()) {
+                throw std::runtime_error("line " + std::to_string(line + 1) + " should be terminated with a newline");
+            }
+            char val = input.get();
+            if (val == 'e' || val == 'E') {
+                in_exponent = true;
+                break;
+            } else if (is_terminator(val)) {
+                return value;
+            } else if (!std::isdigit(val)) {
+                throw std::runtime_error("invalid fraction containing '" + std::string(1, val) + "' at " + get_location(column, line));
+            }
+            fractional *= 10;
+            value += (val - '0') / fractional;
+            input.advance();
+        } 
+    }
+
+    if (in_exponent) {
+        if (value < 1 || value >= 10) {
+            throw std::runtime_error("absolute value of mantissa should be within [1, 10) at " + get_location(column, line));
+        }
+
+        input.advance();
+        if (!input.valid()) {
+            throw std::runtime_error("line " + std::to_string(line + 1) + " should be terminated with a newline");
+        }
+
+        char val = input.get();
+        if (!std::isdigit(val)) {
+            if (val == '-') {
+                negative_exponent = true;
+            } else if (val != '+') {
+                throw std::runtime_error("'e/E' should be followed by a sign or digit in number at " + get_location(column, line));
+            }
+            input.advance();
+
+            if (!input.valid()) {
+                throw std::runtime_error("line " + std::to_string(line + 1) + " should be terminated with a newline");
+            }
+            val = input.get();
+            if (!std::isdigit(val)) {
+                throw std::runtime_error("exponent sign must be followed by at least one digit in number at " + get_location(column, line));
             }
         }
 
-    } else {
-        double first = 0;
-        try {
-            first = to_number_simple<false>(x, e_found);
-        } catch (std::exception& e) {
-            throw std::runtime_error("failed to convert mantissa to number:\n  - " + std::string(e.what()));
-        }
+        exponent += (val - '0');
+        input.advance();
+        while (1) {
+            if (!input.valid()) {
+                throw std::runtime_error("line " + std::to_string(line + 1) + " should be terminated with a newline");
+            }
+            char val = input.get();
+            if (is_terminator(val)) {
+                break;
+            } else if (!std::isdigit(val)) {
+                throw std::runtime_error("invalid exponent containing '" + std::string(1, val) + "' at " + get_location(column, line));
+            }
+            exponent *= 10;
+            exponent += (val - '0');
+            input.advance();
+        } 
 
-        double afirst = std::abs(first);
-        if (afirst < 1 || afirst >= 10) {
-            throw std::runtime_error("absolute value of mantissa should be within [1, 10)");
-        }
-
-        double second = 0;
-        try {
-            second = to_number_simple<true>(x + e_found + 1, n - e_found - 1);
-        } catch (std::exception& e) {
-            throw std::runtime_error("failed to convert exponent to an integer:\n  - " + std::string(e.what()));
-        }
-
-        val = first * std::pow(10.0, second); 
-    }
-
-    return val;
-}
-
-inline std::complex<double> to_complex(const char* x, size_t n) {
-    // First pass through to identify the _second_ +/- sign.
-    // We skip the first character, as this is either a number
-    // for the real part or the first +/- sign.
-    int separator = -1;
-    for (size_t i = 1; i < n; ++i) {
-        if (x[i] == '-' || x[i] == '+') {
-            separator = i;
-            break;
+        if (exponent) {
+            if (negative_exponent) {
+                exponent *= -1;
+            }
+            value *= std::pow(10.0, exponent);
         }
     }
 
-    if (n && x[n-1] != 'i') {
-        throw std::runtime_error("last character of a complex number should be 'i'");
-    }
-
-    if (separator < 0) {
-        throw std::runtime_error("could not find separator between the real and imaginary parts");
-    }
-
-    double real;
-    try {
-        real = to_number(x, separator);
-    } catch (std::exception& e) {
-        throw std::runtime_error("failed to parse the real part:\n  - " + std::string(e.what()));
-    }
-
-    double imag;
-    try {
-        imag = to_number(x + separator, n - separator - 1); // include the separator to define the sign, but ignore the trailing 'i'.
-    } catch (std::exception& e) {
-        throw std::runtime_error("failed to parse the imaginary part:\n  - " + std::string(e.what()));
-    }
-
-    return std::complex<double>(real, imag);
-}
-
-inline bool to_boolean(const char* x, size_t n) {
-    if (n == 4 && std::tolower(x[0]) == 't' 
-        && std::tolower(x[1]) == 'r' 
-        && std::tolower(x[2]) == 'u'
-        && std::tolower(x[3]) == 'e') {
-        return true;
-    }
-
-    if (n == 5 && std::tolower(x[0]) == 'f'
-        && std::tolower(x[1]) == 'a'
-        && std::tolower(x[2]) == 'l'
-        && std::tolower(x[3]) == 's'
-        && std::tolower(x[4]) == 'e') {
-        return false;
-    }
-
-    throw std::runtime_error("invalid string representation for a boolean");
-    return true;
+    return value;
 }
 
 }

--- a/include/comservatory/convert.hpp
+++ b/include/comservatory/convert.hpp
@@ -13,7 +13,8 @@ inline std::string get_location(size_t column, size_t line) {
     return std::string("field ") + std::to_string(column + 1) + " of line " + std::to_string(line + 1);
 }
 
-// Assumes that the first character is the double quote.
+// Assumes that 'input' is located on the opening double quote. On return,
+// 'input' is left on the next character _after_ the closing double quote.
 template<class Input>
 std::string to_string(Input& input, size_t column, size_t line) {
     std::string output;
@@ -44,6 +45,9 @@ std::string to_string(Input& input, size_t column, size_t line) {
     return output;
 }
 
+// Assumes that 'input' is located on the first letter of the keyword (i.e.,
+// before the first letter of 'lower'). On return, 'input' is left on the
+// first character _after_ the end of the keyword.
 template<class Input>
 void expect_fixed(Input& input, const std::string& lower, const std::string& upper, size_t column, size_t line) {
     for (size_t i = 0; i < lower.size(); ++i) {
@@ -58,6 +62,8 @@ void expect_fixed(Input& input, const std::string& lower, const std::string& upp
     }
 }
 
+// Assumes that 'input' is located on the first digit. On return, 'input' is
+// left on the first character _after_ the end of the number.
 template<class Input>
 double to_number(Input& input, size_t column, size_t line) {
     double value = 0;

--- a/tests/src/Field.cpp
+++ b/tests/src/Field.cpp
@@ -146,65 +146,6 @@ TEST(FieldTest, DummyMissing) {
     EXPECT_EQ(ptr->size(), 4);
 }
 
-TEST(FieldTest, Decider) {
-    {
-        std::string x = "\"asdascd\"";
-        EXPECT_EQ(comservatory::decide_type(x.c_str(), x.size()), comservatory::STRING);
-    }
-
-    {
-        std::string x = "12345";
-        EXPECT_EQ(comservatory::decide_type(x.c_str(), x.size()), comservatory::NUMBER);
-    }
-
-    {
-        std::string x = "10+12345i";
-        EXPECT_EQ(comservatory::decide_type(x.c_str(), x.size()), comservatory::COMPLEX);
-    }
-
-    {
-        std::string x = "FALSE";
-        EXPECT_EQ(comservatory::decide_type(x.c_str(), x.size()), comservatory::BOOLEAN);
-    }
-
-    {
-        std::string x = "true";
-        EXPECT_EQ(comservatory::decide_type(x.c_str(), x.size()), comservatory::BOOLEAN);
-    }
-
-    {
-        std::string x = "NA";
-        EXPECT_EQ(comservatory::decide_type(x.c_str(), x.size()), comservatory::UNKNOWN);
-    }
-
-    {
-        std::string x = "12345E2";
-        EXPECT_EQ(comservatory::decide_type(x.c_str(), x.size()), comservatory::NUMBER);
-    }
-
-    {
-        std::string x = "12345";
-        EXPECT_EQ(comservatory::decide_type(x.c_str(), x.size()), comservatory::NUMBER);
-    }
-
-    {
-        std::string x = "-12345";
-        EXPECT_EQ(comservatory::decide_type(x.c_str(), x.size()), comservatory::NUMBER);
-    }
-
-    {
-        std::string x = "";
-        EXPECT_ANY_THROW({
-            try {
-                comservatory::decide_type(x.c_str(), 0);
-            } catch (std::exception& e) {
-                EXPECT_THAT(std::string(e.what()), ::testing::HasSubstr("empty"));
-                throw;
-            }
-        });
-    }
-}
-
 TEST(FieldTest, Creator) {
     comservatory::DefaultFieldCreator<false> fun;
 

--- a/tests/src/Parser.cpp
+++ b/tests/src/Parser.cpp
@@ -250,22 +250,20 @@ TEST(LoadTest, Failures) {
 }
 
 TEST(LoadTest, ParallelFailures) {
-    {
-        std::string x = "\"aaron\",\"britney\",\"aaron\"\n1,2,3\n";
-        byteme::RawBufferReader reader(raw_bytes(x), x.size());
+    std::string x = "\"aaron\",\"britney\",\"aaron\"\n1,2,3\n";
+    ChunkedBufferReader<10> reader(raw_bytes(x), x.size());
 
-        comservatory::ReadCsv parser;
-        parser.parallel = true;
+    comservatory::ReadCsv parser;
+    parser.parallel = true;
 
-        EXPECT_ANY_THROW({
-            try {
-                parser.read(reader);
-            } catch (std::exception& e) {
-                EXPECT_THAT(std::string(e.what()), ::testing::HasSubstr("duplicated header"));
-                throw;
-            }
-        });
-    }
+    EXPECT_ANY_THROW({
+        try {
+            parser.read(reader);
+        } catch (std::exception& e) {
+            EXPECT_THAT(std::string(e.what()), ::testing::HasSubstr("duplicated header"));
+            throw;
+        }
+    });
 }
 
 TEST(LoadTest, CustomCreator) {

--- a/tests/src/Parser.cpp
+++ b/tests/src/Parser.cpp
@@ -239,109 +239,14 @@ TEST(LoadTest, DummyByIndex) {
 }
 
 TEST(LoadTest, Failures) {
-    {
-        std::string x = "\"aaron\",\"britney\",\"aaron\"\n1,2,3\n";
-        byteme::RawBufferReader reader(raw_bytes(x), x.size());
-        EXPECT_ANY_THROW({
-            try {
-            load_simple(reader);
-            } catch (std::exception& e) {
-                EXPECT_THAT(std::string(e.what()), ::testing::HasSubstr("duplicated header"));
-                throw;
-            }
-        });
-    }
-
-    {
-        std::string x = "\"aaron\",\"britney\",\"foo\"\n1,2\n";
-        byteme::RawBufferReader reader(raw_bytes(x), x.size());
-        EXPECT_ANY_THROW({
-            try {
-            load_simple(reader);
-            } catch (std::exception& e) {
-                EXPECT_THAT(std::string(e.what()), ::testing::HasSubstr("fewer fields"));
-                throw;
-            }
-        });
-    }
-
-    {
-        std::string x = "\"aaron\",\"britney\",\"foo\"\n1,2,3,4\n";
-        byteme::RawBufferReader reader(raw_bytes(x), x.size());
-        EXPECT_ANY_THROW({
-            try {
-            load_simple(reader);
-            } catch (std::exception& e) {
-                EXPECT_THAT(std::string(e.what()), ::testing::HasSubstr("more fields"));
-                throw;
-            }
-        });
-    }
-
-    {
-        std::string x = "\"aaron\",\"britney\",\"foo\"\n1,2,3\nTRUE,3,4\n";
-        byteme::RawBufferReader reader(raw_bytes(x), x.size());
-        EXPECT_ANY_THROW({
-            try {
-            load_simple(reader);
-            } catch (std::exception& e) {
-                EXPECT_THAT(std::string(e.what()), ::testing::HasSubstr("previous and current types"));
-                throw;
-            }
-        });
-    }
-
-    {
-        std::string x = "\"aaron\",\"britney\",\"foo\"\n1,2,3\n3\"asd,3,4\n";
-        byteme::RawBufferReader reader(raw_bytes(x), x.size());
-        EXPECT_ANY_THROW({
-            try {
-            load_simple(reader);
-            } catch (std::exception& e) {
-                EXPECT_THAT(std::string(e.what()), ::testing::HasSubstr("encountered quote"));
-                throw;
-            }
-        });
-    }
-
-    {
-        std::string x = "\"aaron\",\"britney\",\"foo\"\n1,2,\"asdasd\"\n4,3,\"asdasd\n";
-        byteme::RawBufferReader reader(raw_bytes(x), x.size());
-        EXPECT_ANY_THROW({
-            try {
-                load_simple(reader);
-            } catch (std::exception& e) {
-                EXPECT_THAT(std::string(e.what()), ::testing::HasSubstr("not terminated by a double quote"));
-                throw;
-            }
-        });
-    }
-
-    {
-        std::string x = "\"aaron\",\"britney\",\"foo\"\n1,2,\"asdasd\"\n\n4,3,\"asdasd\"";
-        byteme::RawBufferReader reader(raw_bytes(x), x.size());
-        EXPECT_ANY_THROW({
-            try {
-                load_simple(reader);
-            } catch (std::exception& e) {
-                EXPECT_THAT(std::string(e.what()), ::testing::HasSubstr("empty line"));
-                throw;
-            }
-        });
-    }
-
-    {
-        std::string x = "\"aaron\",\"britney\",\"foo\"\n1,2,\"asdasd\"\n4,3,\"asdasd\"";
-        byteme::RawBufferReader reader(raw_bytes(x), x.size());
-        EXPECT_ANY_THROW({
-            try {
-                load_simple(reader);
-            } catch (std::exception& e) {
-                EXPECT_THAT(std::string(e.what()), ::testing::HasSubstr("terminated by a single"));
-                throw;
-            }
-        });
-    }
+    parse_fail("\"aaron\",\"britney\",\"aaron\"\n1,2,3\n", "duplicated header");
+    parse_fail("\"aaron\",\"britney\",\"foo\"\n1,2\n", "fewer fields");
+    parse_fail("\"aaron\",\"britney\",\"foo\"\n1,2,3,4\n", "more fields");
+    parse_fail("\"aaron\",\"britney\",\"foo\"\n1,2,3\nTRUE,3,4\n", "previous and current types");
+    parse_fail("\"aaron\",\"britney\",\"foo\"\n1,2,3\n3\"asd,3,4\n", "invalid number containing '\"'");
+    parse_fail("\"aaron\",\"britney\",\"foo\"\n1,2,\"asdasd\"\n4,3,\"asdasd\n", "truncated string");
+    parse_fail("\"aaron\",\"britney\",\"foo\"\n1,2,\"asdasd\"\n\n4,3,\"asdasd\"\n", "is empty");
+    parse_fail("\"aaron\",\"britney\",\"foo\"\n1,2,\n4,3,4\n", "is empty");
 }
 
 TEST(LoadTest, CustomCreator) {

--- a/tests/src/convert_boolean.cpp
+++ b/tests/src/convert_boolean.cpp
@@ -1,65 +1,36 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
+
 #include "comservatory/convert.hpp"
 
+#include "utils.h"
+
+bool convert_to_boolean(std::string x) {
+    x = "\"foo\"\n" + x + "\n";
+    byteme::RawBufferReader reader(reinterpret_cast<const unsigned char*>(x.c_str()), x.size());
+    comservatory::ReadCsv parser;
+
+    auto output = parser.read(reader);
+    EXPECT_EQ(output.fields.size(), 1);
+    EXPECT_EQ(output.fields[0]->type(), comservatory::BOOLEAN);
+
+    const auto& v = static_cast<const comservatory::FilledBooleanField*>(output.fields[0].get())->values;
+    EXPECT_EQ(v.size(), 1);
+    return v[0];
+}
+
 TEST(ConvertTest, Boolean) {
-    {
-        std::string x = "TRUE";
-        EXPECT_TRUE(comservatory::to_boolean(x.c_str(), x.size()));
-    }
-
-    {
-        std::string x = "true";
-        EXPECT_TRUE(comservatory::to_boolean(x.c_str(), x.size()));
-    }
-
-    {
-        std::string x = "True";
-        EXPECT_TRUE(comservatory::to_boolean(x.c_str(), x.size()));
-    }
-
-    {
-        std::string x = "FALSE";
-        EXPECT_FALSE(comservatory::to_boolean(x.c_str(), x.size()));
-    }
-
-    {
-        std::string x = "false";
-        EXPECT_FALSE(comservatory::to_boolean(x.c_str(), x.size()));
-    }
-
-    {
-        std::string x = "False";
-        EXPECT_FALSE(comservatory::to_boolean(x.c_str(), x.size()));
-    }
+    EXPECT_TRUE(convert_to_boolean("TRUE"));
+    EXPECT_TRUE(convert_to_boolean("true"));
+    EXPECT_TRUE(convert_to_boolean("True"));
+    EXPECT_FALSE(convert_to_boolean("FALSE"));
+    EXPECT_FALSE(convert_to_boolean("false"));
+    EXPECT_FALSE(convert_to_boolean("False"));
 }
 
 TEST(ConvertTest, BooleanFail) {
-    // Wrong length.
-    {
-        std::string x = "falset";
-        EXPECT_ANY_THROW({
-            try {
-                comservatory::to_boolean(x.c_str(), x.size());
-            } catch (std::exception& e) {
-                std::string msg(e.what());
-                EXPECT_THAT(msg, ::testing::HasSubstr("boolean"));
-                throw;
-            }
-        });
-    }
-
-    // Bad words.
-    {
-        std::string x = "falsT";
-        EXPECT_ANY_THROW({
-            try {
-                comservatory::to_boolean(x.c_str(), x.size());
-            } catch (std::exception& e) {
-                std::string msg(e.what());
-                EXPECT_THAT(msg, ::testing::HasSubstr("boolean"));
-                throw;
-            }
-        });
-    }
+    simple_conversion_fail("Tru", "truncated keyword");
+    simple_conversion_fail("Tank", "unknown keyword");
+    simple_conversion_fail("True", "last line must be terminated");
+    simple_conversion_fail("falsey", "trailing");
 }

--- a/tests/src/convert_complex.cpp
+++ b/tests/src/convert_complex.cpp
@@ -57,4 +57,5 @@ TEST(ConvertTest, ComplexFail) {
     simple_conversion_fail("1i", "incorrectly formatted number");
     simple_conversion_fail("21+i", "incorrectly formatted complex number");
     simple_conversion_fail("21+5a", "invalid number containing 'a'");
+    simple_conversion_fail("21+5,", "incorrectly formatted complex number");
 }

--- a/tests/src/convert_complex.cpp
+++ b/tests/src/convert_complex.cpp
@@ -1,81 +1,60 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
+
 #include "comservatory/convert.hpp"
+#include "utils.h"
+
+std::complex<double> convert_to_complex(std::string x) {
+    x = "\"foo\"\n" + x + "\n";
+    byteme::RawBufferReader reader(reinterpret_cast<const unsigned char*>(x.c_str()), x.size());
+    comservatory::ReadCsv parser;
+
+    auto output = parser.read(reader);
+    EXPECT_EQ(output.fields.size(), 1);
+    EXPECT_EQ(output.fields[0]->type(), comservatory::COMPLEX);
+
+    const auto& v = static_cast<const comservatory::FilledComplexField*>(output.fields[0].get())->values;
+    EXPECT_EQ(v.size(), 1);
+    return v[0];
+}
 
 TEST(ConvertTest, Complex) {
     {
-        std::string x = "1.2+1.3i";
-        auto out = comservatory::to_complex(x.c_str(), x.size());
+        auto out = convert_to_complex("1.2+1.3i");
         EXPECT_EQ(out.real(), 1.2);
         EXPECT_EQ(out.imag(), 1.3);
     }
 
     {
-        std::string x = "1.2-2e4i";
-        auto out = comservatory::to_complex(x.c_str(), x.size());
+        auto out = convert_to_complex("1+1i");
+        EXPECT_EQ(out.real(), 1);
+        EXPECT_EQ(out.imag(), 1);
+    }
+
+    {
+        auto out = convert_to_complex("1.2-2e4i");
         EXPECT_EQ(out.real(), 1.2);
         EXPECT_EQ(out.imag(), -2e4);
     }
 
     {
-        std::string x = "-9.2e3-7.6i";
-        auto out = comservatory::to_complex(x.c_str(), x.size());
+        auto out = convert_to_complex("0+0i");
+        EXPECT_EQ(out.real(), 0);
+        EXPECT_EQ(out.imag(), 0);
+    }
+
+    {
+        auto out = convert_to_complex("-9.2e3-7.6i");
         EXPECT_EQ(out.real(), -9.2e3);
         EXPECT_EQ(out.imag(), -7.6);
     }
 }
 
 TEST(ConvertTest, ComplexFail) {
-    {
-        std::string x = "1";
-        EXPECT_ANY_THROW({
-            try {
-                comservatory::to_complex(x.c_str(), x.size());
-            } catch (std::exception& e) {
-                std::string msg(e.what());
-                EXPECT_THAT(msg, ::testing::HasSubstr("last character"));
-                throw;
-            }
-        });
-    }
-
-    {
-        std::string x = "1i";
-        EXPECT_ANY_THROW({
-            try {
-                comservatory::to_complex(x.c_str(), x.size());
-            } catch (std::exception& e) {
-                std::string msg(e.what());
-                EXPECT_THAT(msg, ::testing::HasSubstr("could not find separator"));
-                throw;
-            }
-        });
-    }
-
-    {
-        std::string x = "++1i";
-        EXPECT_ANY_THROW({
-            try {
-                comservatory::to_complex(x.c_str(), x.size());
-            } catch (std::exception& e) {
-                std::string msg(e.what());
-                EXPECT_THAT(msg, ::testing::HasSubstr("failed to parse the real part"));
-                throw;
-            }
-        });
-    }
-
-    {
-        std::string x = "1+i";
-        EXPECT_ANY_THROW({
-            try {
-                comservatory::to_complex(x.c_str(), x.size());
-            } catch (std::exception& e) {
-                std::string msg(e.what());
-                EXPECT_THAT(msg, ::testing::HasSubstr("failed to parse the imaginary part"));
-                throw;
-            }
-        });
-    }
+    simple_conversion_fail("1+", "truncated complex number");
+    simple_conversion_fail("1+\n", "incorrectly formatted complex number");
+    simple_conversion_fail("1+i", "incorrectly formatted complex number");
+    simple_conversion_fail("1i", "incorrectly formatted number");
+    simple_conversion_fail("21+i", "incorrectly formatted complex number");
+    simple_conversion_fail("21+5a", "invalid number containing 'a'");
 }
-

--- a/tests/src/convert_number.cpp
+++ b/tests/src/convert_number.cpp
@@ -102,4 +102,10 @@ TEST(ConvertTest, NumberFail) {
     simple_conversion_fail("1e+0", "should be terminated with a newline");
     simple_conversion_fail("1e+1a", "invalid exponent containing 'a'");
     simple_conversion_fail("2e1.1", "invalid exponent containing '.'");
+
+    simple_conversion_fail("N", "truncated keyword");
+    simple_conversion_fail("Nt", "unknown keyword");
+    simple_conversion_fail("NA", "should terminate with a newline");
+    simple_conversion_fail("Na", "truncated keyword");
+    simple_conversion_fail("Na\n", "unknown keyword");
 }

--- a/tests/src/convert_number.cpp
+++ b/tests/src/convert_number.cpp
@@ -103,6 +103,11 @@ TEST(ConvertTest, NumberFail) {
     simple_conversion_fail("1e+1a", "invalid exponent containing 'a'");
     simple_conversion_fail("2e1.1", "invalid exponent containing '.'");
 
+    simple_conversion_fail("+", "truncated field");
+    simple_conversion_fail("+a\n", "invalid number");
+    simple_conversion_fail("-", "truncated field");
+    simple_conversion_fail("-x\n", "incorrectly formatted number");
+
     simple_conversion_fail("N", "truncated keyword");
     simple_conversion_fail("Nt", "unknown keyword");
     simple_conversion_fail("NA", "should terminate with a newline");

--- a/tests/src/utils.h
+++ b/tests/src/utils.h
@@ -1,6 +1,10 @@
 #ifndef UTILS_H 
 #define UTILS_H 
 
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "byteme/RawBufferReader.hpp"
 #include "comservatory/comservatory.hpp"
 
 inline const unsigned char* raw_bytes(const std::string& x) {
@@ -44,6 +48,25 @@ inline comservatory::Contents validate_path(std::string path) {
     comservatory::ReadCsv foo;
     foo.validate_only = true;
     return foo.read(path);
+}
+
+inline void parse_fail(const std::string& x, const std::string& msg) {
+    byteme::RawBufferReader reader(reinterpret_cast<const unsigned char*>(x.c_str()), x.size());
+    comservatory::ReadCsv parser;
+
+    EXPECT_ANY_THROW({
+        try {
+            parser.read(reader);
+        } catch (std::exception& e) {
+            EXPECT_THAT(std::string(e.what()), ::testing::HasSubstr(msg));
+            throw;
+        }
+    });
+}
+
+inline void simple_conversion_fail(std::string x, const std::string& msg) {
+    x = "\"foo\"\n" + x;
+    parse_fail(x, msg);
 }
 
 #endif


### PR DESCRIPTION
Specifically, we avoid carrying around all the variables indicating whether we're inside a string or not, etc. We also avoid an initial copy over to a buffer as we can decide on the type immediately. This simplifies the code.

It requires a more up-to-date version of byteme, as we're using the new PerByte class (and its parallel equivalent) to scroll through the Reader.